### PR TITLE
C# package fix

### DIFF
--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -35,7 +35,7 @@ ${GO_OUTDIR}/gw/juzu.pb.gw.go: juzu.proto
 
 ## C#
 ## https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli
-VERSION="0.9.0"
+VERSION=0.9.0-rc1
 NUGET_API_KEY="" # Must be set to push the nuget package.
 
 cs_deps:
@@ -52,6 +52,7 @@ cs_push:
 	dotnet nuget push \
 		./csharp-juzu/bin/Debug/Juzu-SDK.${VERSION}.nupkg \
 		-k ${NUGET_API_KEY} \
+		-s https://api.nuget.org/v3/index.json
 
 clean:
 	rm -rf juzupb

--- a/grpc/csharp-juzu/Client.cs
+++ b/grpc/csharp-juzu/Client.cs
@@ -7,9 +7,9 @@ using Grpc.Core;
 
 namespace JuzusvrClient {
 
-    delegate void ResponseHandler(CobaltSpeech.Juzu.DiarizationResponse resp);
+    public delegate void ResponseHandler(CobaltSpeech.Juzu.DiarizationResponse resp);
     
-    class Client {
+    public class Client {
 
         private string serverURL;
         private Grpc.Core.ChannelCredentials creds;
@@ -122,7 +122,7 @@ namespace JuzusvrClient {
         }
     }
 
-    struct DiarizationConfig {
+    public struct DiarizationConfig {
         public string JuzuModelID;
         public string CubicModelID;
         public uint NumSpeakers;


### PR DESCRIPTION
This should fix the errors clients were seeing with the 0.9.0 package.
Nuget doesn't let you overwrite existing versions, so I had to change the suffix.  Optionally, we could bump the patch number (0.9.1).  I'll leave the versioning decision (0.9.0-rc1 vs 0.9.1) up to you @shahruk10.  I'm happy either way, but I would probably lean towards `0.9.1`.

I did push the built sdk as version `0.9.0-rc1`.  I fought with the package manager for a while to get it to resolve to the `rc1` version instead of the problematic `0.9.0`.  The secret command line incantation that fixed it for me was `Install-Package Juzu-SDK -Version 0.9.0-rc1`.  This uninstalled 0.9.0, and then installed 0.9.0-rc1.

The demo client project you sent me seemed to work for me after I made that change!  🎉 