### PR TITLE
Shahruk/c# keepalive workaround

### DIFF
--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -35,7 +35,7 @@ ${GO_OUTDIR}/gw/juzu.pb.gw.go: juzu.proto
 
 ## C#
 ## https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli
-VERSION="0.9.2"
+VERSION="0.9.3-rc1"
 NUGET_API_KEY="" # Must be set to push the nuget package.
 
 cs_deps:

--- a/grpc/csharp-juzu/juzu.csproj
+++ b/grpc/csharp-juzu/juzu.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
    <PackageId>Juzu-SDK</PackageId>
-    <Version>0.9.2</Version>
+    <Version>0.9.3-rc1</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Shahruk Hossain</Authors>
     <Company>Cobalt Speech and Language, Inc.</Company>
@@ -15,8 +15,8 @@
   <ItemGroup>
     <PackageReference Include="Google.Api.CommonProtos" Version="1.7.0" />
     <PackageReference Include="Google.Protobuf" Version="3.10.0" />
-    <PackageReference Include="Grpc" Version="2.24.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.24.0">
+    <PackageReference Include="Grpc" Version="2.26.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.26.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Keepalive is not natively supported by the C# gRPC API yet. 

- As a result, in some cases, such as when Juzu is deployed to Azure, the period of inactivity in the channel between the end of audio stream and results coming back from the server may exceed the idle time imposed by the server environment. This leads to the channel being closed and the results not coming back.

- This commit adds a workaround for keepalive in the C# SDK by pinging the server every minute after the end of audio stream.

