### PR TITLE
py: update time between keepalive pings

### DIFF
--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -66,7 +66,7 @@ py-test:
 #########################
 
 ## https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli
-VERSION="0.9.3"
+VERSION="0.9.4"
 NUGET_API_KEY="" # Must be set to push the nuget package.
 
 cs_deps:

--- a/grpc/csharp-juzu/juzu.csproj
+++ b/grpc/csharp-juzu/juzu.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
    <PackageId>Juzu-SDK</PackageId>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Shahruk Hossain</Authors>
     <Company>Cobalt Speech and Language, Inc.</Company>

--- a/grpc/go-juzu/juzupb/gw/go.mod
+++ b/grpc/go-juzu/juzupb/gw/go.mod
@@ -3,7 +3,7 @@ module github.com/cobaltspeech/sdk-juzu/grpc/go-juzu/juzupb/gw
 go 1.13
 
 require (
-	github.com/cobaltspeech/sdk-juzu/grpc/go-juzu v0.9.3 // indirect
+	github.com/cobaltspeech/sdk-juzu/grpc/go-juzu v0.9.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.11.3 // indirect
 	google.golang.org/grpc v1.24.0 // indirect
 )

--- a/grpc/py-juzu/juzu/client.py
+++ b/grpc/py-juzu/juzu/client.py
@@ -88,8 +88,8 @@ class Client(object):
         self._channelOpts.append(('grpc.http2.max_pings_without_data', 0))
 
         # Minimum time between sending successive ping frames without receiving any
-        # data frame, Int valued, milliseconds. Set to 10 seconds.
-        self._channelOpts.append(('grpc.http2.min_time_between_pings_ms', 10 * 1000))
+        # data frame, Int valued, milliseconds. Set to 6 minutes.
+        self._channelOpts.append(('grpc.http2.min_time_between_pings_ms', 6 * 60 * 1000))
 
         if insecure:
             # no transport layer security (TLS)

--- a/grpc/py-juzu/setup.py
+++ b/grpc/py-juzu/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='cobalt-juzu',
     python_requires='>=3.5.0',
-    version='0.9.3',
+    version='0.9.4',
     description='This client library is designed to support the Cobalt API for speech diarization with Juzu',
     author='Cobalt Speech and Language Inc.',
     maintainer_email='tech@cobaltspeech.com',


### PR DESCRIPTION
- set the minimum time between keepalive pings sent to the server to 6 minutes
  to prevent the connection closing on GOAWAY

- updated versions to 0.9.4