### PR TITLE
c#: fixed bug in sending bytes to the server

### DIFF
--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -66,7 +66,7 @@ py-test:
 #########################
 
 ## https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli
-VERSION="0.9.4"
+VERSION="0.9.5"
 NUGET_API_KEY="" # Must be set to push the nuget package.
 
 cs_deps:

--- a/grpc/csharp-juzu/Client.cs
+++ b/grpc/csharp-juzu/Client.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
 
@@ -164,7 +165,8 @@ namespace JuzusvrClient {
                     int bytesRead;
                     var buffer = new byte[chunkSize];
                     while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0) {
-                        var bytes = Google.Protobuf.ByteString.CopyFrom(buffer);
+                        var bufferNewBytes = buffer.Take(bytesRead).ToArray();
+                        var bytes = Google.Protobuf.ByteString.CopyFrom(bufferNewBytes);
                         request.Audio.Data = bytes;
                         await call.RequestStream.WriteAsync(request);
                     }

--- a/grpc/csharp-juzu/juzu.csproj
+++ b/grpc/csharp-juzu/juzu.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
    <PackageId>Juzu-SDK</PackageId>
-    <Version>0.9.4</Version>
+    <Version>0.9.5</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Shahruk Hossain</Authors>
     <Company>Cobalt Speech and Language, Inc.</Company>

--- a/grpc/go-juzu/juzupb/gw/go.mod
+++ b/grpc/go-juzu/juzupb/gw/go.mod
@@ -3,7 +3,7 @@ module github.com/cobaltspeech/sdk-juzu/grpc/go-juzu/juzupb/gw
 go 1.13
 
 require (
-	github.com/cobaltspeech/sdk-juzu/grpc/go-juzu v0.9.4 // indirect
+	github.com/cobaltspeech/sdk-juzu/grpc/go-juzu v0.9.5// indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.11.3 // indirect
 	google.golang.org/grpc v1.24.0 // indirect
 )

--- a/grpc/py-juzu/setup.py
+++ b/grpc/py-juzu/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='cobalt-juzu',
     python_requires='>=3.5.0',
-    version='0.9.4',
+    version='0.9.5',
     description='This client library is designed to support the Cobalt API for speech diarization with Juzu',
     author='Cobalt Speech and Language Inc.',
     maintainer_email='tech@cobaltspeech.com',


### PR DESCRIPTION
- The C# client code would supply a byte array of length 8192 to the audio stream, expecting all of it to be written onto. It would then send this byte array to the server. This is a bug since there is no guarantee that all 8192 bytes have been written, such as when we are at the end of a stream, or when the stream does not currently have enough bytes to fill the buffer.

- The fix makes the client send only the new bytes written into the buffer from the stream, to the server (which maybe < 8192 bytes).

- The version has been bumped to 0.9.5